### PR TITLE
arrival and departure IDs in the public API Regression tests

### DIFF
--- a/Collections/04_CTC Traders API Regression Pack.postman_collection.json
+++ b/Collections/04_CTC Traders API Regression Pack.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "329723c6-f760-47e4-84f3-e662475e94c8",
+		"_postman_id": "6de60be7-8002-4fa1-a4cc-8c8cb9c24f85",
 		"name": "04_CTC Traders API Regression Pack",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -7953,6 +7953,67 @@
 							"response": []
 						},
 						{
+							"name": "8.8 Get Arrival with omitted Arrival id",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Get messages must return status code 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"if (pm.response.code !== 400) {",
+											"    return;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disabledSystemHeaders": {
+									"accept": true
+								}
+							},
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/vnd.hmrc.1.0+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseURL}}/customs/transits/movements/arrivals/messages",
+									"host": [
+										"{{baseURL}}"
+									],
+									"path": [
+										"customs",
+										"transits",
+										"movements",
+										"arrivals",
+										"messages"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "8.5 GET messages -Invalid Version",
 							"event": [
 								{
@@ -9376,6 +9437,60 @@
 										"transits",
 										"movements",
 										"departures"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get departures omitted departure id",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Get requested departure without ID must return status code 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"if (pm.response.code !== 400) {",
+											"    return;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.hmrc.1.0+json",
+										"type": "text"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{access_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseURL}}/customs/transits/movements/departures/messages?",
+									"host": [
+										"{{baseURL}}"
+									],
+									"path": [
+										"customs",
+										"transits",
+										"movements",
+										"departures",
+										"messages"
+									],
+									"query": [
+										{
+											"key": "",
+											"value": null
+										}
 									]
 								}
 							},


### PR DESCRIPTION
Added regression test to error messages when the get request doesn't have a departure or arrival id
[https://jira.tools.tax.service.gov.uk/browse/CTDA-1490]